### PR TITLE
修复use-rest-page-api的类型声明错误、默认查询条件处理等问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix:修复 useRestPageApi 的 crud 响应转换器类型声明错误
 - breakchange: rawResponse 在有转换器的情况下返回值是直接获取来的数据而不是转换后的数据
+- improve: 添加`setDefaultSearchParams`方法更新默认查询条件
 
 ## v0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.4.0
 
 - fix:修复 useRestPageApi 的 crud 响应转换器类型声明错误
+- breakchange: rawResponse 在有转换器的情况下返回值是直接获取来的数据而不是转换后的数据
 
 ## v0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 版本变更说明
 
+## v0.4.0
+
+- fix:修复 useRestPageApi 的 crud 响应转换器类型声明错误
+
 ## v0.3.0
 
 - breakchange: setItem 方法不再返回更新之后的`item`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## v0.4.0
 
-- fix:修复 useRestPageApi 的 crud 响应转换器类型声明错误
-- breakchange: rawResponse 在有转换器的情况下返回值是直接获取来的数据而不是转换后的数据
-- improve: 添加`setDefaultSearchParams`方法更新默认查询条件
+- fix:修复 useRestPageApi 的 crud 响应转换器类型声明错误 #5
+- breakchange: rawResponse 在有转换器的情况下返回值是直接获取来的数据而不是转换后的数据 #6
+- improve: 添加`setDefaultSearchParams`方法更新默认查询条件 #4
 
 ## v0.3.0
 

--- a/README.md
+++ b/README.md
@@ -654,6 +654,8 @@ const isLoading = dataSource.isLoading;
 
 // 获取是否加载列表数据失败的状态
 const isError = dataSource.isError;
+// 设置默认查询条件
+dataSource.setDefaultSearchParams({userName:'张三'});
 ```
 
 注意：这里介绍的`getItemById`、`updateItem`、`setItem`、`addItem`、`removeItemById`这些方法只会与`dataSource.items`进行交互，不会与 RESTful CRUD API 进行交互。如果需要与 RESTful CRUD API 交互，参见[与增删改查 API 交互](#与增删改查-api-交互)。

--- a/src/__test__/useRestPageApi.spec.tsx
+++ b/src/__test__/useRestPageApi.spec.tsx
@@ -1241,3 +1241,36 @@ it('获取列表数据时，即使有转化器，rawResponse是转换前的值',
 
   expect(result.current.rawResponse).toEqual(rawResponse);
 });
+
+it('设置默认查询条件，获取数据会使用新的默认查询条件', async () => {
+  (http.get as jest.Mock).mockResolvedValue({
+    content: [
+      { userId: '2', userName: '李四', age: 20 },
+      { userId: '1', userName: '张三', age: 27 },
+    ],
+    number: 0,
+    size: 10,
+    totalElements: 2,
+  });
+  const defaultSearchParams = { userName: '张三' };
+
+  const { result, waitForNextUpdate } = renderHook(() =>
+    useRestPageApi('/test', undefined, {
+      keyName: 'userId',
+      defaultSearchParams,
+    }),
+  );
+
+  await waitForNextUpdate();
+
+  expect(result.current.defaultSearchParams).toEqual({ userName: '张三' });
+  expect(result.current.searchParams).toEqual({ userName: '张三' });
+
+  result.current.setDefaultSearchParams({ userName: '李四' });
+
+  await waitForNextUpdate();
+
+  expect(http.get).toHaveBeenCalledTimes(2);
+  expect(result.current.defaultSearchParams).toEqual({ userName: '李四' });
+  expect(result.current.searchParams).toEqual({ userName: '李四' });
+});

--- a/src/__test__/useRestPageApi.spec.tsx
+++ b/src/__test__/useRestPageApi.spec.tsx
@@ -1210,3 +1210,34 @@ it('删除数据响应数据转换器', async () => {
   expect(result.current.items.length).toBe(2);
   expect(http.get).toHaveBeenCalledTimes(1);
 });
+
+it('获取列表数据时，即使有转化器，rawResponse是转换前的值', async () => {
+  const rawResponse = {
+    data: [
+      { userId: '2', userName: '李四', age: 20 },
+      { userId: '1', userName: '张三', age: 27 },
+    ],
+    number: 0,
+    size: 10,
+    totalElements: 2,
+  };
+  (http.get as jest.Mock).mockResolvedValue(rawResponse);
+
+  const { result, waitForNextUpdate } = renderHook(() =>
+    useRestPageApi('/test', undefined, {
+      keyName: 'userId',
+      transformListResponse: (response: any) => ({
+        content: response.data,
+        number: response.number,
+        size: response.size,
+        totalElements: response.totalElements,
+      }),
+    }),
+  );
+  await waitForNextUpdate();
+
+  result.current.fetch();
+  await waitForNextUpdate();
+
+  expect(result.current.rawResponse).toEqual(rawResponse);
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -270,4 +270,7 @@ export interface RestPageResponseInfo<T, RawResponse> {
    * 重置
    */
   reset: () => void;
+  setDefaultSearchParams: (searchParams: {
+    [x: string]: string;
+  }) => Promise<PageResponse<T>>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
-import { HttpRequestConfig, HttpResponse } from '@sinoui/http';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { HttpRequestConfig } from '@sinoui/http';
 /**
  * 排序信息
  */
@@ -115,7 +116,7 @@ export interface Options<T> {
   /**
    * 指定分页列表查询结果的转换器
    */
-  transformListResponse?: (response: HttpResponse) => PageResponse<any>;
+  transformListResponse?: (response: any) => PageResponse<T>;
   /**
    * 指定分页查询条件转换器
    */
@@ -126,7 +127,7 @@ export interface Options<T> {
   /**
    * 指定获取单条数据的响应数据转换器
    */
-  transformFetchOneResponse?: (response: HttpResponse) => T;
+  transformFetchOneResponse?: (response: any) => T;
   /**
    * 指定新增数据的请求数据转换器
    */
@@ -134,7 +135,7 @@ export interface Options<T> {
   /**
    * 指定新增数据的响应数据转换器
    */
-  transformSaveResponse?: (response: HttpResponse) => T;
+  transformSaveResponse?: (response: any) => T;
   /**
    * 指定更新数据的请求数据转换器
    */
@@ -142,7 +143,7 @@ export interface Options<T> {
   /**
    * 指定更新数据的响应数据转换器
    */
-  transformUpdateResponse?: (response: HttpResponse) => T;
+  transformUpdateResponse?: (response: any) => T;
   /**
    * 指定删除数据的响应数据转换器
    */

--- a/src/useRestPageApi.ts
+++ b/src/useRestPageApi.ts
@@ -18,7 +18,7 @@ import useSyncToHistory from './useSyncToHistory';
  * @param {Options<T>} [options] 配置项
  * @returns
  */
-function useRestPageApi<T, RawResponse = PageResponse<T>>(
+function useRestPageApi<T, RawResponse = any>(
   url: string,
   defaultValue: T[] = [],
   options: Options<T> = {},
@@ -86,7 +86,7 @@ function useRestPageApi<T, RawResponse = PageResponse<T>>(
           payload: { ...result, sorts, number: pageNo, size: pageSize },
         });
 
-        rawResponseRef.current = result as any;
+        rawResponseRef.current = response as any;
         return result;
       } catch (e) {
         dispatch({ type: 'FETCH_FAILURE' });

--- a/src/useRestPageApi.ts
+++ b/src/useRestPageApi.ts
@@ -78,7 +78,7 @@ function useRestPageApi<T, RawResponse = PageResponse<T>>(
         );
 
         const result = transformListResponse
-          ? transformListResponse(response as any)
+          ? transformListResponse(response)
           : response;
 
         dispatch({
@@ -288,7 +288,7 @@ function useRestPageApi<T, RawResponse = PageResponse<T>>(
       try {
         const response: T = await http.get(`${baseUrl}/${id}`);
         const result = transformFetchOneResponse
-          ? transformFetchOneResponse(response as any)
+          ? transformFetchOneResponse(response)
           : response;
 
         if (isNeedUpdate) {
@@ -318,7 +318,7 @@ function useRestPageApi<T, RawResponse = PageResponse<T>>(
           : itemInfo;
         const response: T = await http.post(baseUrl, info);
         const result = transformSaveResponse
-          ? transformSaveResponse(response as any)
+          ? transformSaveResponse(response)
           : response;
 
         if (isNeedUpdate) {
@@ -353,7 +353,7 @@ function useRestPageApi<T, RawResponse = PageResponse<T>>(
         const response: T = await http.put(`${baseUrl}/${info[keyName]}`, info);
 
         const result = transformUpdateResponse
-          ? transformUpdateResponse(response as any)
+          ? transformUpdateResponse(response)
           : response;
 
         if (isNeedUpdate) {

--- a/src/useRestPageApi.ts
+++ b/src/useRestPageApi.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useReducer, useCallback, useRef, useMemo, useEffect } from 'react';
+import { useReducer, useCallback, useRef, useMemo } from 'react';
 import http from '@sinoui/http';
 import { PageResponse, Options, SortInfo, RestPageResponseInfo } from './types';
 import reducer, { Reducer } from './reducer';


### PR DESCRIPTION
- 修复 useRestPageApi 的 crud 响应转换器类型声明错误 Closes #5 
- 处理rawResponse 在有转换器的情况下返回值是直接获取来的数据而不是转换后的数据 Closes #6 
- 添加`setDefaultSearchParams`方法更新默认查询条件 Closes #4 